### PR TITLE
Tag fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ gulp
 
 ## Change log
 
+0.0.9
+
+* Correct parsing of hours in twelve hour mode (v 0.0.8 not in master)
+
 0.0.8
 
 * Correct parsing of hours in twelve hour mode

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "clockpicker",
   "description": "A clock-style timepicker for Bootstrap (or jQuery)",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "main": [
     "dist/jquery-clockpicker.js",
     "dist/jquery-clockpicker.css"

--- a/bower.json
+++ b/bower.json
@@ -22,10 +22,10 @@
       "homepage": "http://wangshenwei.com/"
     }
   ],
-  "homepage": "http://weareoutman.github.io/clockpicker/",
+  "homepage": "http://linagora.org/",
   "repository": {
     "type": "git",
-    "url": "git://github.com/weareoutman/clockpicker.git"
+    "url": "git://github.com/linagora/clockpicker.git"
   },
   "dependencies": {
     "jquery" : ">=1.7"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clockpicker",
   "description": "A clock-style timepicker for Bootstrap (or jQuery)",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "author": {
     "name": "Wang Shenwei",
     "email": "wangshenwei@qq.com",

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
     "email": "wangshenwei@qq.com",
     "url": "http://wangshenwei.com/"
   },
-  "homepage": "http://weareoutman.github.io/clockpicker/",
+  "homepage": "http://linagora.org/",
   "repository": {
     "type": "git",
-    "url": "git://github.com/weareoutman/clockpicker.git"
+    "url": "git://github.com/linagora/clockpicker.git"
   },
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
Hi guys, 
Current tag 0.0.8 is by mistake created on the wrong commit, as a result obsolete code is downloaded (it's version before merge) and bower install produce warning:
[ERROR] bower lng-clockpicker#~0.0.8             mismatch Version declared in the json (0.0.7) is different than the resolved one (0.0.8)

I don't know why but i cant add an issue to this repo (maybe it's because it's a fork), so i created this pull request you can reject it if you want and just fix that tag (move 0.0.8 to your most recent commit) :) 
Thanks in advance!
